### PR TITLE
Improve hexagon game visuals and mechanics

### DIFF
--- a/HexagonBounce/src/ball.js
+++ b/HexagonBounce/src/ball.js
@@ -29,25 +29,46 @@ export default class Ball {
         return new Ball(x, y, vx, vy, radius);
     }
 
-    update(dt, outerHexagon, innerHexagon = null) {
+    static atCenter(hexagon, speed = 100, radius = 5) {
+        const angle = Math.random() * Math.PI * 2;
+        const vx = Math.cos(angle) * speed;
+        const vy = Math.sin(angle) * speed;
+        return new Ball(hexagon.cx, hexagon.cy, vx, vy, radius);
+    }
+
+    reset(x, y, speed) {
+        const angle = Math.random() * Math.PI * 2;
+        this.x = x;
+        this.y = y;
+        this.vx = Math.cos(angle) * speed;
+        this.vy = Math.sin(angle) * speed;
+    }
+
+    update(dt, outerHexagon, innerHexagons = []) {
         this.x += this.vx * dt;
         this.y += this.vy * dt;
 
         // Check collision with outer hexagon (balls bounce off inner walls)
-        this.checkCollision(outerHexagon);
-        
+        this.checkCollision(outerHexagon, innerHexagons[0]);
+
         // Check collision with inner hexagon if it exists (balls bounce off outer walls)
-        if (innerHexagon) {
-            this.checkInnerCollision(innerHexagon);
+        for (const hex of innerHexagons) {
+            if (hex) {
+                this.checkInnerCollision(hex);
+            }
         }
     }
 
-    checkCollision(hexagon) {
+    checkCollision(hexagon, innerHexagon) {
         const edges = hexagon.edges();
-        for (const [p1, p2] of edges) {
+        for (const { p1, p2, index } of edges) {
             const edge = { x: p2.x - p1.x, y: p2.y - p1.y };
             const cross = edge.x * (this.y - p1.y) - edge.y * (this.x - p1.x);
             if (cross < 0) {
+                if (hexagon.highlightSide !== null && index === hexagon.highlightSide) {
+                    this.reset(innerHexagon.cx, innerHexagon.cy, Math.hypot(this.vx, this.vy));
+                    return;
+                }
                 const len = Math.hypot(edge.x, edge.y);
                 const normal = { x: edge.y / len, y: -edge.x / len };
                 const dist = -cross / len;
@@ -83,7 +104,10 @@ export default class Ball {
 
     draw(ctx) {
         ctx.save();
-        ctx.fillStyle = '#0ff';
+        const grad = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, this.radius);
+        grad.addColorStop(0, '#fff');
+        grad.addColorStop(1, '#0cf');
+        ctx.fillStyle = grad;
         ctx.beginPath();
         ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
         ctx.fill();

--- a/HexagonBounce/src/hexagon.js
+++ b/HexagonBounce/src/hexagon.js
@@ -1,13 +1,14 @@
 import { rotatePoint } from './utils.js';
 
 export default class Hexagon {
-    constructor(cx, cy, radius, omega = 0, missingSide = null) {
+    constructor(cx, cy, radius, omega = 0, missingSide = null, highlightSide = null) {
         this.cx = cx;
         this.cy = cy;
         this.radius = radius;
         this.angle = 0;
         this.omega = omega;
         this.missingSide = missingSide; // null or 0-5 to indicate which side to omit
+        this.highlightSide = highlightSide; // null or 0-5 to indicate side drawn differently
         this.points = this.calculatePoints();
     }
 
@@ -42,38 +43,25 @@ export default class Hexagon {
         }
         const edges = [];
         for (let i = 0; i < 6; i++) {
-            // Skip the missing side if specified
             if (this.missingSide !== null && i === this.missingSide) {
                 continue;
             }
-            edges.push([rotated[i], rotated[(i + 1) % 6]]);
+            edges.push({ p1: rotated[i], p2: rotated[(i + 1) % 6], index: i });
         }
         return edges;
     }
 
     draw(ctx, strokeStyle = '#0f0') {
         ctx.save();
-        ctx.strokeStyle = strokeStyle;
         ctx.lineWidth = 2;
-        ctx.beginPath();
-        
         const edges = this.edges();
-        if (edges.length > 0) {
-            // Start from the first edge's first point
-            ctx.moveTo(edges[0][0].x, edges[0][0].y);
-            
-            // Draw each edge
-            for (const [p1, p2] of edges) {
-                ctx.lineTo(p2.x, p2.y);
-            }
-            
-            // Only close the path if no side is missing
-            if (this.missingSide === null) {
-                ctx.closePath();
-            }
+        for (const { p1, p2, index } of edges) {
+            ctx.beginPath();
+            ctx.moveTo(p1.x, p1.y);
+            ctx.lineTo(p2.x, p2.y);
+            ctx.strokeStyle = (this.highlightSide !== null && index === this.highlightSide) ? '#f00' : strokeStyle;
+            ctx.stroke();
         }
-        
-        ctx.stroke();
         ctx.restore();
     }
 }

--- a/HexagonBounce/src/main.js
+++ b/HexagonBounce/src/main.js
@@ -27,6 +27,7 @@ let last = 0;
 let fps = 0;
 let fpsInterval = 0;
 let outerHexagon;
+let middleHexagon;
 let innerHexagon;
 const balls = [];
 
@@ -58,16 +59,18 @@ function createHexagons() {
     const centerX = canvas.width / 2;
     const centerY = canvas.height / 2;
     const outerRadius = Math.min(canvas.width, canvas.height) * outerScale / 2;
-    const innerRadius = outerRadius * innerRatio;
+    const middleRadius = outerRadius * innerRatio;
+    const innerRadius = middleRadius * 0.5;
 
-    outerHexagon = new Hexagon(centerX, centerY, outerRadius, outerSpeed);
-    innerHexagon = new Hexagon(centerX, centerY, innerRadius, innerSpeed, 0);
+    outerHexagon = new Hexagon(centerX, centerY, outerRadius, outerSpeed, null, 0);
+    middleHexagon = new Hexagon(centerX, centerY, middleRadius, innerSpeed);
+    innerHexagon = new Hexagon(centerX, centerY, innerRadius, 0);
 }
 
 function createBalls() {
     balls.length = 0;
     for (let i = 0; i < numBalls; i++) {
-        balls.push(Ball.randomInside(outerHexagon, ballSpeed, ballRadius));
+        balls.push(Ball.atCenter(innerHexagon, ballSpeed, ballRadius));
     }
 }
 
@@ -82,9 +85,10 @@ function setupControlEvents() {
         ballRadius = parseFloat(controls.ballRadius.value);
 
         outerHexagon.omega = outerSpeed;
-        innerHexagon.omega = innerSpeed;
+        middleHexagon.omega = innerSpeed;
         outerHexagon.setRadius(Math.min(canvas.width, canvas.height) * outerScale / 2);
-        innerHexagon.setRadius(outerHexagon.radius * innerRatio);
+        middleHexagon.setRadius(outerHexagon.radius * innerRatio);
+        innerHexagon.setRadius(middleHexagon.radius * 0.5);
 
         for (const b of balls) {
             b.setSpeed(ballSpeed);
@@ -114,6 +118,7 @@ function init() {
     window.addEventListener('resize', () => {
         resize();
         createHexagons();
+        createBalls();
     });
 
     setupControlEvents();
@@ -137,16 +142,18 @@ function loop(timestamp) {
 
 function update(dt) {
     outerHexagon.update(dt);
+    middleHexagon.update(dt);
     innerHexagon.update(dt);
     for (const b of balls) {
-        b.update(dt, outerHexagon, innerHexagon);
+        b.update(dt, outerHexagon, [innerHexagon, middleHexagon]);
     }
 }
 
 function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    outerHexagon.draw(ctx); // Green outer hexagon
-    innerHexagon.draw(ctx, '#ff0'); // Yellow inner hexagon
+    outerHexagon.draw(ctx, '#0f0');
+    middleHexagon.draw(ctx, '#ff0');
+    innerHexagon.draw(ctx, '#09f');
     
     for (const b of balls) {
         b.draw(ctx);

--- a/HexagonBounce/style.css
+++ b/HexagonBounce/style.css
@@ -1,7 +1,7 @@
 html, body {
     margin: 0;
     height: 100%;
-    background: #111;
+    background: radial-gradient(#222, #000);
     overflow: hidden;
     color: #fff;
     font-family: sans-serif;
@@ -10,6 +10,7 @@ html, body {
 #canvas {
     display: block;
     margin: 0 auto;
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
 }
 
 #controls {
@@ -19,6 +20,7 @@ html, body {
     background: rgba(0, 0, 0, 0.6);
     padding: 10px;
     border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     font-size: 14px;
 }
 


### PR DESCRIPTION
## Summary
- spawn balls at the inner hexagon centre
- add a middle hexagon and highlight one outer edge in red
- respawn balls when touching the red edge
- draw hexagons and balls with more attractive colours
- tweak CSS styling

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint cannot load config)*

------
https://chatgpt.com/codex/tasks/task_e_687f6f76355c832cb1f0f23994a85fc5